### PR TITLE
[ADD] eco_utils

### DIFF
--- a/custom-addons/eco_utils/__init__.py
+++ b/custom-addons/eco_utils/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom-addons/eco_utils/__manifest__.py
+++ b/custom-addons/eco_utils/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Ecosoft Co., Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Eco Utils",
+    "summary": "Useful server side fuctions",
+    "version": "13.0.1.0.0",
+    "category": "Tools",
+    "author": "Ecosoft",
+    "installable": True,
+    "depends": ["base"],
+    "data": [
+    ],
+}

--- a/custom-addons/eco_utils/models/__init__.py
+++ b/custom-addons/eco_utils/models/__init__.py
@@ -1,0 +1,1 @@
+from . import utils

--- a/custom-addons/eco_utils/models/utils.py
+++ b/custom-addons/eco_utils/models/utils.py
@@ -1,0 +1,185 @@
+# Copyright 2020 Ecosoft Co., Ltd.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
+
+
+class EcoUtils(models.AbstractModel):
+    _name = 'eco.utils'
+    _description = 'Utils Class'
+
+    @api.model
+    def friendly_create_data(self, model, data_dict, auto_create={}):
+        """ Accept friendly data_dict in following format to create data
+            data_dict:
+            {'field1': value1,
+             'field2_id': value2,  # can be ID or name search string
+             'line_ids': [{
+                'field2': value2,
+             }]
+            }
+           auto_create:
+            {'field2_id': {'name': 'Test'}, ...}
+            Auto create master data, if not found.
+            Only for many2one on header, not for lines
+        """
+        res = {}
+        rec = self.env[model].new()  # Dummy reccord
+        rec_fields = []
+        line_fields = []
+        for field, model_field in rec._fields.items():
+            if field in data_dict and model_field.type != 'one2many':
+                rec_fields.append(field)
+            elif field in data_dict:
+                line_fields.append(field)
+        rec_dict = {k: v for k, v in data_dict.items() if k in rec_fields}
+        rec_dict = self._finalize_data_to_write(rec, rec_dict,
+                                                auto_create=auto_create)
+        # Prepare Line Dict (o2m)
+        for line_field in line_fields:
+            final_line_dict = []
+            # Loop all o2m lines, and recreate it
+            for line_data_dict in data_dict[line_field]:
+                rec_fields = []
+                line_fields = []
+                for field, model_field in rec[line_field]._fields.items():
+                    if field in line_data_dict and \
+                            model_field.type != 'one2many':
+                        rec_fields.append(field)
+                    elif field in line_data_dict:
+                        line_fields.append(field)
+                line_dict = {k: v for k, v in line_data_dict.items()
+                             if k in rec_fields}
+                if line_fields:
+                    raise ValidationError(_('friendly_create_data() support '
+                                            'only 1 level of one2many lines'))
+                line_dict = self._finalize_data_to_write(rec[line_field],
+                                                         line_dict)
+                final_line_dict.append((0, 0, line_dict))
+            rec_dict[line_field] = final_line_dict
+        obj = rec.create(rec_dict)
+        res = {
+            'is_success': True,
+            'result': {
+                'id': obj.id,
+            },
+            'messages': _('Record created successfully'),
+        }
+        return res
+
+    @api.model
+    def friendly_update_data(self, model, data_dict, key_field, auto_create={}):
+        """ Accept friendly data_dict in following format to update existing rec
+        This method, will always delete o2m lines and recreate it.
+            data_dict:
+            {'field1': value1,
+             'line_ids': [{
+                'field2': value2,
+             }]
+            }
+            key_field: search field, i.e., number
+           auto_create:
+            {'field2_id': {'name': 'Test'}, ...}
+            Auto create master data, if not found.
+            Only for many2one on header, not for lines
+        """
+        res = {}
+        # Prepare Header Dict (non o2m)
+        if not key_field or key_field not in data_dict:
+            raise ValidationError(
+                _('Method update_data() key_field is not valid!'))
+        rec = self.env[model].search([(key_field, '=', data_dict[key_field])])
+        if not rec:
+            raise ValidationError(_('Search key "%s" not found!') %
+                                  data_dict[key_field])
+        elif len(rec) > 1:
+            raise ValidationError(_('Search key "%s" found mutiple matches!') %
+                                  data_dict[key_field])
+        rec_fields = []
+        line_fields = []
+        for field, model_field in rec._fields.items():
+            if field in data_dict and model_field.type != 'one2many':
+                rec_fields.append(field)
+            elif field in data_dict:
+                line_fields.append(field)
+        rec_dict = {k: v for k, v in data_dict.items() if k in rec_fields}
+        rec_dict = self._finalize_data_to_write(rec, rec_dict,
+                                                auto_create=auto_create)
+        # Prepare Line Dict (o2m)
+        for line_field in line_fields:
+            lines = rec[line_field]
+            # First, delete all lines o2m
+            lines.unlink()
+            final_line_dict = []
+            final_line_append = final_line_dict.append
+            # Loop all o2m lines, and recreate it
+            for line_data_dict in data_dict[line_field]:
+                rec_fields = []
+                rec_fields_append = rec_fields.append
+                line_fields = []
+                for field, model_field in rec[line_field]._fields.items():
+                    if field in line_data_dict and \
+                            model_field.type != 'one2many':
+                        rec_fields_append(field)
+                    elif field in line_data_dict:
+                        line_fields.append(field)
+                line_dict = {k: v for k, v in line_data_dict.items()
+                             if k in rec_fields}
+                if line_fields:
+                    raise ValidationError(_('friendly_update_data() support '
+                                            'only 1 level of one2many lines'))
+                line_dict = self._finalize_data_to_write(lines, line_dict)
+                final_line_append((0, 0, line_dict))
+            rec_dict[line_field] = final_line_dict
+        rec.write(rec_dict)
+        res = {
+            'is_success': True,
+            'result': {
+                'id': rec.id,
+            },
+            'messages': _('Record updated successfully'),
+        }
+        return res
+
+    @api.model
+    def _finalize_data_to_write(self, rec, rec_dict, auto_create={}):
+        """ For many2one, many2many, use name search to get id """
+        final_dict = {}
+        for key, value in rec_dict.items():
+            ftype = rec._fields[key].type
+            if key in rec_dict.keys() and ftype in ('many2one', 'many2many'):
+                model = rec._fields[key].comodel_name
+                Model = self.env[model]
+                if rec_dict[key] and isinstance(rec_dict[key], str):
+                    search_vals = []
+                    if ftype == 'many2one':
+                        search_vals = [rec_dict[key]]
+                    elif ftype == 'many2many':
+                        search_vals = rec_dict[key].split(',')
+                        value = []  # for many2many, result will be tuple
+                    for val in search_vals:
+                        values = Model.name_search(val, operator='=')
+                        # If failed, try again by ID
+                        if len(values) != 1:
+                            if val and isinstance(val, int):
+                                rec = Model.search([('id', '=', val)])
+                                if len(rec) == 1:
+                                    values = [(rec.id, )]
+                        # If not found, but auto_create it
+                        if len(values) != 1 and auto_create.get(key):
+                            res = self.friendly_create_data(model, auto_create[key])
+                            values = [(res['result']['id'], )]
+                        # --
+                        if len(values) > 1:
+                            raise ValidationError(
+                                _('"%s" matched more than 1 record') % val)
+                        elif not values:
+                            raise ValidationError(
+                                _('"%s" found no match.') % val)
+                        if ftype == 'many2one':
+                            value = values[0][0]
+                        elif ftype == 'many2many':
+                            value.append((4, values[0][0]))
+            final_dict.update({key: value})
+        return final_dict

--- a/custom-addons/eco_utils/readme/CONTRIBUTORS.rst
+++ b/custom-addons/eco_utils/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kitti U. <kittiu@ecosoft.co.th>

--- a/custom-addons/eco_utils/readme/DESCRIPTION.rst
+++ b/custom-addons/eco_utils/readme/DESCRIPTION.rst
@@ -1,0 +1,4 @@
+This module provide 2 useful server side function to ease creation of a record,
+
+* friendly_create_data(model, data_dict, auto_create={})
+* friendly_update_data(model, data_dict, key_field, auto_create={})

--- a/custom-addons/eco_utils_test/__init__.py
+++ b/custom-addons/eco_utils_test/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/custom-addons/eco_utils_test/__manifest__.py
+++ b/custom-addons/eco_utils_test/__manifest__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Ecosoft Co., Ltd.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+{
+    "name": "Eco Utils",
+    "summary": "Useful server side fuctions",
+    "version": "13.0.1.0.0",
+    "category": "Tools",
+    "author": "Ecosoft",
+    "installable": True,
+    "depends": ["eco_utils", "sale"],
+    "data": [
+    ],
+}

--- a/custom-addons/eco_utils_test/models/__init__.py
+++ b/custom-addons/eco_utils_test/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale

--- a/custom-addons/eco_utils_test/models/sale.py
+++ b/custom-addons/eco_utils_test/models/sale.py
@@ -1,0 +1,58 @@
+# Copyright 2020 Ecosoft Co., Ltd.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class EcoUtils(models.Model):
+    """ Sample use of eco.utils create_data, addong more logics """
+    _inherit = 'sale.order'
+
+    @api.model
+    def sample_create_sale_order(self, vals):
+        _logger.info('sample_create_sale_order(), input: %s' % vals)
+        try:
+            Utils = self.env['eco.utils']
+            res = Utils.friendly_create_data(self._name, vals)
+            if res['is_success']:
+                res_id = res['result']['id']
+                sale = self.browse(res_id)
+                # BUSINESS LOGIC, i.e., overwrite some sale order value
+                sale.write({'client_order_ref': 'Test Test Test'})
+                # return more data
+                res['result']['order_number'] = sale.name
+                res['result']['client_order_ref'] = sale.client_order_ref
+        except Exception as e:
+            res = {
+                'is_success': False,
+                'result': False,
+                'messages': _(str(e)),
+            }
+            self._cr.rollback()
+        _logger.info('sample_create_sale_order(), output: %s' % res)
+        return res
+
+    @api.model
+    def sample_create_update_sale_order(self, vals):
+        _logger.info('sample_create_update_sale_order(), input: %s' % vals)
+        try:  # Update
+            if not self.search([('name', '=', vals.get('name'))]):
+                return self.sample_create_sale_order(vals)  # fall back to create
+            Utils = self.env['eco.utils']
+            res = Utils.friendly_update_data(self._name, vals, 'name')
+            if res['is_success']:
+                res_id = res['result']['id']
+                p = self.browse(res_id)
+                res['result']['name'] = p.name
+        except Exception as e:
+            res = {
+                'is_success': False,
+                'result': False,
+                'messages': _(str(e)),
+            }
+            self._cr.rollback()
+        _logger.info('sample_create_update_sale_order(), output: %s' % res)
+        return res

--- a/custom-addons/eco_utils_test/readme/CONTRIBUTORS.rst
+++ b/custom-addons/eco_utils_test/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Kitti U. <kittiu@ecosoft.co.th>

--- a/custom-addons/eco_utils_test/readme/DESCRIPTION.rst
+++ b/custom-addons/eco_utils_test/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This module test functions from eco_utils, and also provide the sample
+implementation of function that use eco.utils
+
+* sample_create_sale_order(vals)
+* sample_create_update_sale_order(vals)

--- a/custom-addons/eco_utils_test/tests/__init__.py
+++ b/custom-addons/eco_utils_test/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_utils

--- a/custom-addons/eco_utils_test/tests/test_utils.py
+++ b/custom-addons/eco_utils_test/tests/test_utils.py
@@ -1,0 +1,157 @@
+# Copyright 2019 Ecosoft Co., Ltd., Kitti U. <kittiu@ecosoft.co.th>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase
+
+
+class TestPurchaseDeposit(TransactionCase):
+    def setUp(self):
+        super(TestPurchaseDeposit, self).setUp()
+        self.partner_model = self.env['res.partner']
+        self.product_model = self.env['product.product']
+        self.utils_model = self.env['eco.utils']
+        self.sale_model = self.env['sale.order']
+
+        self.partner1 = self.partner_model.create({'name': 'Test Cust 1'})
+        self.partner2 = self.partner_model.create({'name': 'Test Cust 2'})
+        self.partner_dup = self.partner_model.create({'name': 'Test Cust Duplicated'})
+        self.partner_dup2 = self.partner_model.create({'name': 'Test Cust Duplicated'})
+        self.product1 = self.product_model.create(
+            {
+                'name': 'Test Product 1',
+                'type': 'service',
+                'default_code': 'PROD1',
+            }
+        )
+        self.product2 = self.product_model.create(
+            {
+                'name': 'Test Product 2',
+                'type': 'service',
+                'default_code': 'PROD2',
+            }
+        )
+        self.test_sale_vals = {
+            'partner_id': 'Test Cust 1',
+            'order_line': [
+                {
+                    'product_id': 'PROD1',
+                    'product_uom_qty': 1,
+                    'price_unit': 100,
+                },
+                {
+                    'product_id': 'PROD2',
+                    'product_uom_qty': 2,
+                    'price_unit': 100,
+                }
+            ]
+        }
+
+    def test_friendly_create_data(self):
+        # If partner and product one matching, create OK
+        res = self.utils_model.friendly_create_data(
+            'sale.order', self.test_sale_vals
+        )
+        self.assertTrue(res['is_success'])
+        sale = self.sale_model.browse(res['result']['id'])
+        self.assertEqual(len(sale.order_line), 2)
+
+        # If partner find > 1 matched, can't create order
+        with self.assertRaises(ValidationError):
+            res = self.utils_model.friendly_create_data(
+                'sale.order', {'partner_id': 'Test Cust Duplicated'}
+            )
+
+        # If partner Cust X not found, can't create order
+        with self.assertRaises(ValidationError):
+            res = self.utils_model.friendly_create_data(
+                'sale.order', {'partner_id': 'Test Cust X'}
+            )
+
+        # If partner Cust X not found, but auto_create it, order can create
+        res = self.utils_model.friendly_create_data(
+            'sale.order', {'partner_id': 'Test Cust X'},
+            auto_create={'partner_id': {'name': 'Test Cust X'}}
+        )
+        sale = self.sale_model.browse(res['result']['id'])
+        self.assertEqual(sale.partner_id.name, 'Test Cust X')
+
+    def test_friendly_update_data(self):
+        # If partner and product one matching, create OK
+        res = self.utils_model.friendly_create_data(
+            'sale.order', self.test_sale_vals
+        )
+        self.assertTrue(res['is_success'])
+        sale = self.sale_model.browse(res['result']['id'])
+        self.assertEqual(len(sale.order_line), 2)
+
+        # Update same sale order's date using name is search_key
+        self.utils_model.friendly_update_data(
+            'sale.order',
+            {'name': sale.name, 'client_order_ref': 'Cust Ref', 'partner_id': 'Test Cust 2'},
+            'name'  # search_key
+        )
+        self.assertEqual(sale.client_order_ref, 'Cust Ref')
+        self.assertEqual(sale.partner_id.name, 'Test Cust 2')
+
+        # Update partner to Cust X, not found
+        with self.assertRaises(ValidationError):
+            self.utils_model.friendly_update_data(
+                'sale.order',
+                {'name': sale.name, 'partner_id': 'Cust X'},
+                'name'  # search_key
+            )
+
+        # Update partner to Cust X, not found but auto_create
+        self.utils_model.friendly_update_data(
+            'sale.order',
+            {'name': sale.name, 'partner_id': 'Cust X'},
+            'name',  # search_key
+            auto_create={'partner_id': {'name': 'Cust X'}}
+        )
+
+        # Update lines, is equal to delete and create again
+        self.utils_model.friendly_update_data(
+            'sale.order',
+            {'name': sale.name,
+             'order_line': [
+                {
+                     'product_id': 'PROD1',
+                     'product_uom_qty': 2,
+                     'price_unit': 100,
+                     'tax_id': False,
+                 },
+                 {
+                     'product_id': 'PROD2',
+                     'product_uom_qty': 3,
+                     'price_unit': 100,
+                     'tax_id': False,
+                 }
+             ]},
+            'name',
+        )
+        self.assertEqual(sale.amount_total, 500)  # equal to the new lines
+
+
+    def test_sample_sale_create_data(self):
+        # sample_sale_create_data will have more info in the result
+        res = self.sale_model.sample_create_sale_order(self.test_sale_vals)
+        self.assertTrue('order_number' in res['result'] and
+                        'client_order_ref' in res['result'])
+
+    def test_sample_sale_create_update_data(self):
+        # If not exists, create. If exists update it
+        test_number = 'SOXXX'
+        self.test_sale_vals.update({'name': test_number})
+        s1 = self.sale_model.search_count([])
+        # Do create / update first time, a new sale order created
+        res = self.sale_model.sample_create_update_sale_order(self.test_sale_vals)
+        s2 = self.sale_model.search_count([])
+        self.assertEqual(s2-s1, 1)
+        # Do create / update again
+        res = self.sale_model.sample_create_update_sale_order(self.test_sale_vals)
+        s3 = self.sale_model.search_count([])
+        self.assertEqual(s3-s2, 0)
+
+        # sale = self.sale_model.browse(res['result']['id'])
+        # self.assertNotEqual(test_number, sale.name)


### PR DESCRIPTION
Provide 2 useful functions, expect to help creating API easier.
2 functions,
- create_data(mode, data_dict, auto_create={})
- update_data(mode, data_dict, search_key, auto_create={})

Accept friendly data_dict in following format to create data

```
{
    'field1': value1,
    'field2_id': value2,  # can be ID or name search string
    'line_ids': [{
        'field2': value2,
    }]
}
```

Also auto_create master data if the many2one field has no matched.

